### PR TITLE
Fix: RTL caret position div creates horizontal scrollbar

### DIFF
--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -56,3 +56,9 @@ float: left !important;
 .rtl .dashboard-right {
   float: left !important;
 }
+
+// Right and left will be flipped by the r2 gem.
+.rtl #caret-clone[style] {
+  right: auto !important;
+  left: -7000px !important;
+}

--- a/vendor/assets/javascripts/caret_position.js
+++ b/vendor/assets/javascripts/caret_position.js
@@ -45,7 +45,7 @@ $.fn.caretPosition = function(options) {
   };
 
   styles = getStyles(textarea[0]);
-  clone = $("<div><p></p></div>").appendTo("body");
+  clone = $("<div id='caret-clone'><p></p></div>").appendTo("body");
   p = clone.find("p");
   clone.width(textarea.width());
   clone.height(textarea.height());


### PR DESCRIPTION
This is the smallest change that can make this work. Another approach would be to remove the rule `left: "-7000px"` from the clone div's inline css and position the div for both LTR and RTL layouts in a css file.

The issue: when using a RTL locale, after inserting a mention in a post, 7000px is added to the left side of the screen. This persists until the page is refreshed.

![caret-pos-one](https://user-images.githubusercontent.com/2975917/33104503-6a6b419e-cedd-11e7-9d2d-f421d91bc806.png)

![caret-position-two](https://user-images.githubusercontent.com/2975917/33104507-72a47754-cedd-11e7-9e4f-6069e6a6ee15.png)
