### PR TITLE
FIX: pending users count

### DIFF
--- a/app/jobs/scheduled/pending_users_reminder.rb
+++ b/app/jobs/scheduled/pending_users_reminder.rb
@@ -22,13 +22,13 @@ module Jobs
           target_usernames = Group[:moderators].users.map do |user|
             next if user.id < 0
 
-            count = user.notifications.joins(:topic)
+            unseen_count = user.notifications.joins(:topic)
               .where("notifications.id > ?", user.seen_notification_id)
               .where("notifications.read = false")
               .where("topics.subtype = ?", TopicSubtype.pending_users_reminder)
               .count
 
-            count == 0 ? user.username : nil
+            unseen_count == 0 ? user.username : nil
           end.compact
 
           unless target_usernames.empty?


### PR DESCRIPTION
There was a report today that the Pending Users Notification is setting the notification title to '0 users waiting for approval' when there are multiple users waiting for approval.

The value for `count` that is being used in the notification template is being overwritten by the `count` that is being set in the query for unseen/unread notifications.